### PR TITLE
PolyLine changes

### DIFF
--- a/nornir_shared/plot.py
+++ b/nornir_shared/plot.py
@@ -217,7 +217,7 @@ class ColorSelectionStyle(Enum):
     BY_LINE_LENGTH = 0
     PER_LINE = 1
 
-def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputFilename=None, xlim=None, ylim=None, Colors=None, ColorStyle=ColorSelectionStyle.BY_LINE_LENGTH, **kwargs):
+def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputFilename=None, xlim=None, ylim=None, XTicks=None, XTickLabels=None, XTickRotation=None, YTicks=None, YTickLabels=None, YTickRotation=None, Colors=None, ColorStyle=ColorSelectionStyle.BY_LINE_LENGTH, **kwargs):
     '''PolyLineList is a nested list in this form:
     lines:
         line1:
@@ -283,6 +283,16 @@ def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputF
         
     if ylim is not None:
         plt.ylim(ylim)
+
+    # Note: Matplotlib doesn't allow labels to be specified without locations,
+    # so XTickLabels will be ignored unless XTicks is present
+    # (The same is true for YTicks)
+
+    if XTicks is not None:
+        plt.xticks(ticks=XTicks, labels=XTickLabels, rotation=XTickRotation)
+
+    if YTicks is not None:
+        plt.yticks(ticks=YTicks, labels=YTickLabels, rotation=YTickRotation)
 
     if(OutputFilename is not None):
         plt.ioff()

--- a/nornir_shared/plot.py
+++ b/nornir_shared/plot.py
@@ -212,7 +212,7 @@ def Scatter(x, y, s=None, c=None, Title=None, XAxisLabel=None, YAxisLabel=None, 
     plt.close()
 
 
-def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputFilename=None, xlim=None, ylim=None, **kwargs):
+def PolyLine(PolyLineList, Title=None, colors=[], XAxisLabel=None, YAxisLabel=None, OutputFilename=None, xlim=None, ylim=None, **kwargs):
     '''PolyLineList is a nested list in this form:
     lines:
         line1:
@@ -224,24 +224,23 @@ def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputF
         ...
     '''
 
-    colors = ['black', 'blue', 'green', 'yellow', 'orange', 'red', 'purple']
     # print Hist.Bins
     plt.cla()
+    num = 0
     for line in PolyLineList:
-        numPoints = len(line[0])
-        colorVal = 'black'
-        
-        if  numPoints < len(colors):
-            colorVal = colors[numPoints]
-            
+        color = 'red'
+        if len(colors) > num:
+            color = colors[num]
+            print(color)
+
+        num += 1
+
         if not 'marker' in kwargs:
-            kwargs['marker'] = '+'
+            kwargs['marker'] = '.'
                         
-        if not 'markerfacecolor' in kwargs:
-            kwargs['markerfacecolor'] = 'r'
+        kwargs['markerfacecolor'] = color
         
-        if not 'markeredgecolor' in kwargs:
-            kwargs['markeredgecolor'] = 'r'
+        kwargs['markeredgecolor'] = color
             
         if not 'markersize' in kwargs:
             kwargs['markersize'] = 5
@@ -249,7 +248,7 @@ def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputF
         if not 'alpha' in kwargs:
             kwargs['alpha'] = 0.5
             
-        plt.plot(line[0], line[1], color=colorVal, **kwargs)
+        plt.plot(line[0], line[1], color=color, **kwargs)
 
     if not Title is None:
         plt.title(Title)

--- a/nornir_shared/plot.py
+++ b/nornir_shared/plot.py
@@ -213,7 +213,16 @@ def Scatter(x, y, s=None, c=None, Title=None, XAxisLabel=None, YAxisLabel=None, 
 
 
 def PolyLine(PolyLineList, Title=None, XAxisLabel=None, YAxisLabel=None, OutputFilename=None, xlim=None, ylim=None, **kwargs):
-    '''Poly line list is a list of lists of x,y points'''
+    '''PolyLineList is a nested list in this form:
+    lines:
+        line1:
+            xAxis: x1, x2, x3, ...
+            yAxis: y1, y2, y3, ...
+        line2:
+            xAxis: ...
+            yAxis: ...
+        ...
+    '''
 
     colors = ['black', 'blue', 'green', 'yellow', 'orange', 'red', 'purple']
     # print Hist.Bins


### PR DESCRIPTION
- Docstring for PolyLine describes data format in a way I find more clear
- Instead of using kwargs for markerfacecolor, markeredgecolor, and selecting line color based on number of points, make lines and markers all the same color, with a convenient arg format for specifying each line's color
- Change default marker to the circle